### PR TITLE
Piif/fix subelements

### DIFF
--- a/timmi-ess-fusion.user.js
+++ b/timmi-ess-fusion.user.js
@@ -261,7 +261,7 @@
     async function refreshFavourites(){
         var itemTitleCell = null;
         if ($('#TSFormWorklist').length == 1){
-            itemTitleCell = $('.tier1').parent().next();
+            itemTitleCell = $('.tier1,.tier2').parent().next();
         }
         else{
             itemTitleCell = $('img[title*="Delete"]').closest('tr').find('td[align="left"]:last');
@@ -338,9 +338,12 @@
         favouritesTable.hide();
         $('.urTbsDiv').css('margin-bottom','20px');
 
+        var favFounds = {};
         $('.urVt1').each(async function() {
-            var savedFavouriteTitle = await getFavourite($(this).text());
-            if (savedFavouriteTitle){
+            var txt = $(this).text();
+            var savedFavouriteTitle = await getFavourite(txt);
+            if (savedFavouriteTitle && ! favFounds.hasOwnProperty(txt)) {
+                favFounds[txt] = true;
                 favouritesTable.show();
                 var favRow = $('<tr></td>');
                 favRow.append($('<td style="vertical-align:middle"><a href="#" class="addFromFavouritesBtn" wbsKey="' + $(this).text() + '">Select</a></td>'));
@@ -373,7 +376,8 @@
 
                     });
                     $('#WLSelectButton').click();
-                });}
+                });
+            }
 
             setButtonStyle($('.addFromFavouritesBtn'));
             $('.addFromFavouritesBtn').css('padding','1px 5px');

--- a/timmi-ess-fusion.user.js
+++ b/timmi-ess-fusion.user.js
@@ -106,58 +106,6 @@
         $('input[id="timesheet_tsdurationdata[2].' + idSuffix + '"]').val(totalEssDayHours.toFixed(2).replace('.',','));
     }
 
-
-    // copy/pasted from https://www.myatos.net/irj/portal?NavigationTarget=navurl%3A%2F%2F84bc02facde559823f00891e66f3af77&atosStandaloneContent=yes&CurrentWindowId=WID1584813492579&supportInitialNavNodesFilter=true&filterViewIdList=%3BAtosEndUser%3B&PrevNavTarget=navurl%3A%2F%2F2cdfd81429dcd018714ec26adff50475&TarTitle=Timesheet%20entry&NavMode=10
-    // + fixed display "block" to "table-row"
-    function toggleRows(elm) {
-        var rows = document.getElementsByTagName("TR");
-        elm.style.backgroundImage = "url(S_RAPOSI.gif)";
-        var newDisplay = "none";
-        var thisID = elm.parentNode.parentNode.parentNode.id + "-";
-        thisID = thisID.replace(/\s+/g,'');//remove any whitespace
-        // Are we expanding or contracting? If the first child is hidden, we expand
-        for (var i = 0; i < rows.length; i++) {
-            var r = rows[i];
-            if (matchStart(r.id, thisID, true)) {
-                if (r.style.display == "none") {
-                    newDisplay = "table-row";
-                    elm.style.backgroundImage = "url(S_RAMINU.gif)";
-                }
-                break;
-            }
-        }
-
-        // When expanding, only expand one level.  Collapse all desendants.
-        var matchDirectChildrenOnly = (newDisplay != "none");
-
-        for (var j = 0; j < rows.length; j++) {
-            var s = rows[j];
-            if (matchStart(s.id, thisID, matchDirectChildrenOnly)) {
-                s.style.display = newDisplay;
-                var cell = s.getElementsByTagName("TD")[0];
-                var tier = cell.getElementsByTagName("DIV")[0];
-                var folder = tier.getElementsByTagName("SPAN")[0];
-                if (folder.getAttribute("onclick") != null) {
-                    var f = folder.getAttribute("onclick").toFunction();
-                    var KP = f.toString();
-                    if (KP.search("toggleRows") != -1){
-                        folder.style.backgroundImage = "url(S_RAPOSI.gif)";}
-                }
-            }
-        }
-    }
-
-    // from https://stackoverflow.com/questions/21271997/how-to-overwrite-a-function-using-a-userscript
-    // there's certainly a cleaner way to do this ...
-    function addJS_Node (text, s_URL, funcToRun, runOnLoad) {
-        var D = document;
-        var scriptNode = D.createElement ('script');
-        scriptNode.type = "text/javascript";
-        scriptNode.textContent = text;
-        var targ = D.getElementsByTagName ('head')[0] || D.body || D.documentElement;
-        targ.appendChild (scriptNode);
-    }
-
     function fixWbsOverviewLayout(){
         if (!isWbsOverviewDisplayed()){
             return;
@@ -166,7 +114,6 @@
         // fix child row sizing
         $('.tier1 > span').click(function(){
             $(this).closest('tr:visible').nextAll().each(function(){
-                var id = $(this).attr('id')+'';
                 if ($(this).css('display') === 'block'){
                     $(this).css('display','table-row');
                 }

--- a/timmi-ess-fusion.user.js
+++ b/timmi-ess-fusion.user.js
@@ -163,7 +163,15 @@
             return;
         }
 
-        addJS_Node (toggleRows);
+        // fix child row sizing
+        $('.tier1 > span').click(function(){
+            $(this).closest('tr:visible').nextAll().each(function(){
+                var id = $(this).attr('id')+'';
+                if ($(this).css('display') === 'block'){
+                    $(this).css('display','table-row');
+                }
+            });
+        });
 
         $('.urTbsDiv').css('height','1%'); // firefox sizing issue
         $('.urTbsDiv').css('background-color','white'); // firefox coloring

--- a/timmi-ess-fusion.user.js
+++ b/timmi-ess-fusion.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Timmi ESS Fusion
 // @namespace    https://github.com/draganignjic/timmi-ess-fusion/
-// @version      0.6.19
+// @version      0.6.20
 // @description  Embed ESS Timesheet in Lucca Timmi
 // @author       Dragan Ignjic (Saferpay)
 // @include      /ZCA_TIMESHEET
@@ -106,10 +106,64 @@
         $('input[id="timesheet_tsdurationdata[2].' + idSuffix + '"]').val(totalEssDayHours.toFixed(2).replace('.',','));
     }
 
+
+    // copy/pasted from https://www.myatos.net/irj/portal?NavigationTarget=navurl%3A%2F%2F84bc02facde559823f00891e66f3af77&atosStandaloneContent=yes&CurrentWindowId=WID1584813492579&supportInitialNavNodesFilter=true&filterViewIdList=%3BAtosEndUser%3B&PrevNavTarget=navurl%3A%2F%2F2cdfd81429dcd018714ec26adff50475&TarTitle=Timesheet%20entry&NavMode=10
+    // + fixed display "block" to "table-row"
+    function toggleRows(elm) {
+        var rows = document.getElementsByTagName("TR");
+        elm.style.backgroundImage = "url(S_RAPOSI.gif)";
+        var newDisplay = "none";
+        var thisID = elm.parentNode.parentNode.parentNode.id + "-";
+        thisID = thisID.replace(/\s+/g,'');//remove any whitespace
+        // Are we expanding or contracting? If the first child is hidden, we expand
+        for (var i = 0; i < rows.length; i++) {
+            var r = rows[i];
+            if (matchStart(r.id, thisID, true)) {
+                if (r.style.display == "none") {
+                    newDisplay = "table-row";
+                    elm.style.backgroundImage = "url(S_RAMINU.gif)";
+                }
+                break;
+            }
+        }
+
+        // When expanding, only expand one level.  Collapse all desendants.
+        var matchDirectChildrenOnly = (newDisplay != "none");
+
+        for (var j = 0; j < rows.length; j++) {
+            var s = rows[j];
+            if (matchStart(s.id, thisID, matchDirectChildrenOnly)) {
+                s.style.display = newDisplay;
+                var cell = s.getElementsByTagName("TD")[0];
+                var tier = cell.getElementsByTagName("DIV")[0];
+                var folder = tier.getElementsByTagName("SPAN")[0];
+                if (folder.getAttribute("onclick") != null) {
+                    var f = folder.getAttribute("onclick").toFunction();
+                    var KP = f.toString();
+                    if (KP.search("toggleRows") != -1){
+                        folder.style.backgroundImage = "url(S_RAPOSI.gif)";}
+                }
+            }
+        }
+    }
+
+    // from https://stackoverflow.com/questions/21271997/how-to-overwrite-a-function-using-a-userscript
+    // there's certainly a cleaner way to do this ...
+    function addJS_Node (text, s_URL, funcToRun, runOnLoad) {
+        var D = document;
+        var scriptNode = D.createElement ('script');
+        scriptNode.type = "text/javascript";
+        scriptNode.textContent = text;
+        var targ = D.getElementsByTagName ('head')[0] || D.body || D.documentElement;
+        targ.appendChild (scriptNode);
+    }
+
     function fixWbsOverviewLayout(){
         if (!isWbsOverviewDisplayed()){
             return;
         }
+
+        addJS_Node (toggleRows);
 
         $('.urTbsDiv').css('height','1%'); // firefox sizing issue
         $('.urTbsDiv').css('background-color','white'); // firefox coloring
@@ -120,6 +174,7 @@
         $('th').css('padding', '5px');
         $('td,th').css('white-space', 'nowrap');
         $('#super').find('td,th').css('border', '1px solid gray');
+        $('.folder').css('display','inline-block'); // unfold/fold button sizing issue
 
         // remove top row with employee and week info for more clean view
         $('#TSFormWorklist').find('table').first().remove();


### PR DESCRIPTION
fixes #8 

first commit :
- modify unfold/fold button style
- overirde toggleRows function in a ugly way, but I don't know how to do it properly in monkey scripts

second commit :
- subelements have tier2 class
- need to store already matched elements because for sub elements, "WBS element" and "A/A Type" have the same class and content, thus favourite list matches 2 items and contains duplicates.